### PR TITLE
Test Julia stable (currently 1.10.2)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ jobs:
           - '1.7'
           - '1.8'
           - '1.9'
+          - '1'
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
This add Julia 1 to testing which currently will point to Julia 1.10.2
